### PR TITLE
fix: error when equipment slot is already used

### DIFF
--- a/src/app/components/party-inventory/party-inventory.component.ts
+++ b/src/app/components/party-inventory/party-inventory.component.ts
@@ -108,6 +108,9 @@ export class PartyInventoryComponent implements OnDestroy {
       if (event.item.usedby && !event.item.usedby.find((e) => e === entity.type)) {
         return this.notify.show(`${entity.name} cannot equip this item`);
       }
+      if (entity[event.slot]) {
+        return this.notify.show(`${entity.name} already has item in ${event.slot}`);
+      }
       this.store.dispatch(new GameStateEquipItemAction({
         entityId: entity.eid,
         slot: event.slot,


### PR DESCRIPTION
First of all, thanks a lot for creating this nice RPG game 👍 🥇 

# What is changed?

Instead of throwing an error in console due to asserstion failure, we now show a message to the user.

# What is the current behavior?

When user tries to assign equipment to a slot that is already in use, the equipment panel stops working, and there is an error in the browser's console:

```
vendor.ebc2536….bundle.js:1 ERROR Error: Assertion Failed: entity already has item short-sword-745a5f66-3c8a-48cb-8621-7493b169b6ad in weapon
    at r (main.f4a9a8e….bundle.js:1)
    at a (main.f4a9a8e….bundle.js:2)
    at vendor.ebc2536….bundle.js:28
    at main.f4a9a8e….bundle.js:4
    at a (main.f4a9a8e….bundle.js:4)
    at e.accumulator (vendor.ebc2536….bundle.js:28)
    at e._tryNext (vendor.ebc2536….bundle.js:29)
    at e._next (vendor.ebc2536….bundle.js:29)
    at e.next (vendor.ebc2536….bundle.js:4)
    at e._next (vendor.ebc2536….bundle.js:16)
```

# What is the new behavior?

Instead of throwing an error, just show the user a friendly message explaining that the slot is already in use.

