### PR TITLE
Fix Goblin Fortress quest line

### DIFF
--- a/src/app/app.imports.ts
+++ b/src/app/app.imports.ts
@@ -7,6 +7,8 @@ import { RouterModule } from '@angular/router';
 import { EffectsModule } from '@ngrx/effects';
 import { StoreRouterConnectingModule } from '@ngrx/router-store';
 import { StoreModule } from '@ngrx/store';
+import { StoreDevtoolsModule } from '@ngrx/store-devtools';
+import { environment } from '../environments/environment';
 import { PowCoreModule } from '../game/pow-core';
 import { AppRoutingModule } from './app-routing.module';
 import { AppEffects } from './app.effects';
@@ -20,6 +22,28 @@ import { SpritesEffects } from './models/sprites/sprites.effects';
 import { CombatModule } from './routes/combat';
 import { WorldModule } from './routes/world';
 import { ServicesModule } from './services';
+
+const storeDevtools = [];
+if (environment.useDevTools) {
+  // TODO: store/devtools disabled because of poor performance.
+  //
+  // Because devtools serializes state to JSON, if you have a large amount of data in your stores (~500 objects)
+  // the time it takes to serialize and deserialize the object becomes significant. This is crippling to the
+  // performance of the app.
+  //
+  // To re-enable the devtools, [fix this](https://github.com/ngrx/store-devtools/issues/57) and then pass
+  // the option to use [Immutable compatible devtools](https://goo.gl/Wym3eT).
+  //
+  // StoreDevtoolsModule.instrumentStore(),
+  // Instrumentation must be imported after importing StoreModule (config is optional)
+  storeDevtools.push([
+    StoreDevtoolsModule.instrument({
+      maxAge: 25, // Retains last 25 states
+      logOnly: environment.production, // Restrict extension to log-only mode
+      autoPause: true, // Pauses recording actions and state changes when the extension window is not open
+    }),
+  ]);
+}
 
 export const APP_IMPORTS = [
   BrowserModule,
@@ -43,17 +67,6 @@ export const APP_IMPORTS = [
   ReactiveFormsModule,
   RouterModule.forRoot(ROUTES, { useHash: true, relativeLinkResolution: 'legacy' }),
   StoreRouterConnectingModule.forRoot(),
-
-  // TODO: store/devtools disabled because of poor performance.
-  //
-  // Because devtools serializes state to JSON, if you have a large amount of data in your stores (~500 objects)
-  // the time it takes to serialize and deserialize the object becomes significant. This is crippling to the
-  // performance of the app.
-  //
-  // To re-enable the devtools, [fix this](https://github.com/ngrx/store-devtools/issues/57) and then pass
-  // the option to use [Immutable compatible devtools](https://goo.gl/Wym3eT).
-  //
-  // StoreDevtoolsModule.instrumentStore(),
-
+  ...storeDevtools,
   EffectsModule.forRoot([GameStateEffects, CombatEffects, SpritesEffects, AppEffects]),
 ];

--- a/src/app/models/game-data/fixed-encounters.ts
+++ b/src/app/models/game-data/fixed-encounters.ts
@@ -59,6 +59,17 @@ export const FIXED_ENCOUNTERS_DATA: ITemplateFixedEncounter[] = [
       'A Goblin spiritual leader of some variety shouts curses as you approach!',
     ],
   },
+  {
+    id: 'goblin-king',
+    enemies: ['goblin-king', 'goblin-wizard', 'goblin-spear', 'goblin-archer'],
+    experience: 200,
+    gold: 100,
+    items: ['goblin-crossbow'],
+    message: [
+      'You face your enemy, the King of the Goblins!',
+      'He is enormous and flanked by well-equipped soldiers.',
+    ],
+  },
 ];
 
 /** Get a fixed encounter descriptor given its id value */

--- a/src/app/models/game-data/game-data.model.ts
+++ b/src/app/models/game-data/game-data.model.ts
@@ -162,9 +162,12 @@ export interface ITemplateEnemy extends ITemplateId {
  * A Combat encounter descriptor.  Used to describe the configuration of combat.
  */
 export interface ITemplateEncounter extends ITemplateId {
-  readonly id: string; // unique id in spreadsheet
-  readonly enemies: string[]; // array of enemies in this encounter
-  readonly message?: string[]; // message to display when combat begins
+  /** Unique ID */
+  readonly id: string;
+  /** array of enemies in this encounter */
+  readonly enemies: string[];
+  /** message to display when combat begins */
+  readonly message?: string[];
 }
 
 /**

--- a/src/app/routes/combat/states/combat-choose-action.state.ts
+++ b/src/app/routes/combat/states/combat-choose-action.state.ts
@@ -106,7 +106,7 @@ export class CombatChooseActionStateComponent
     distinctUntilChanged()
   );
 
-  private _timerSubscription: Subscription;
+  private _timerSubscription?: Subscription;
 
   constructor(
     private renderer: Renderer2,
@@ -133,7 +133,7 @@ export class CombatChooseActionStateComponent
   }
 
   ngOnDestroy(): void {
-    this._timerSubscription.unsubscribe();
+    this._timerSubscription?.unsubscribe();
   }
 
   enter(machine: CombatStateMachineComponent) {

--- a/src/app/routes/combat/states/combat.machine.ts
+++ b/src/app/routes/combat/states/combat.machine.ts
@@ -125,7 +125,7 @@ export class CombatStateMachineComponent
     Immutable.List([])
   );
 
-  private _subscription: Subscription;
+  private _subscription?: Subscription;
 
   @Input() scene: Scene;
   @Input() encounter: CombatEncounter;
@@ -137,7 +137,7 @@ export class CombatStateMachineComponent
   @ViewChildren('start,beginTurn,chooseAction,endTurn,defeat,victory,escape')
   childStates: QueryList<CombatMachineState>;
   ngOnDestroy(): void {
-    this._subscription.unsubscribe();
+    this._subscription?.unsubscribe();
   }
 
   ngAfterViewInit(): void {

--- a/src/app/routes/world/map/features/dialog-feature.component.html
+++ b/src/app/routes/world/map/features/dialog-feature.component.html
@@ -1,5 +1,10 @@
 <div layout="row" layout-padding class="dialog" *ngIf="active$ | async">
   <rpg-sprite class="character" [name]="icon$ | async"></rpg-sprite>
+  <rpg-sprite
+    class="character"
+    [name]="altIcon$ | async"
+    *ngIf="altIcon$ | async"
+  ></rpg-sprite>
   <div flex class="body-text">
     <p [innerText]="title$ | async"></p>
     <span class="text" [innerText]="text$ | async"></span>

--- a/src/app/routes/world/map/features/dialog-feature.component.ts
+++ b/src/app/routes/world/map/features/dialog-feature.component.ts
@@ -31,13 +31,6 @@ export class DialogFeatureComponent extends TiledFeatureComponent {
   @Output() onClose = new EventEmitter();
   active$: Observable<boolean>;
 
-  /** Any game data values to set in this dialog */
-  sets$: Observable<string> = this.feature$.pipe(
-    map((f: TiledMapFeatureData) => {
-      return f.properties.sets;
-    })
-  );
-
   /** The dialog text */
   text$: Observable<string> = this.feature$.pipe(
     map((f: TiledMapFeatureData) => {

--- a/src/app/routes/world/map/features/dialog-feature.component.ts
+++ b/src/app/routes/world/map/features/dialog-feature.component.ts
@@ -6,9 +6,13 @@ import {
   Output,
   ViewEncapsulation,
 } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { AppState } from 'app/app.model';
+import { GameStateSetKeyDataAction } from 'app/models/game-state/game-state.actions';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { IScene } from '../../../../../game/pow2/scene/scene.model';
+import { TileObject } from '../../../../../game/pow2/tile/tile-object';
 import { TiledFeatureComponent, TiledMapFeatureData } from '../map-feature.component';
 
 @Component({
@@ -26,6 +30,13 @@ export class DialogFeatureComponent extends TiledFeatureComponent {
   @Input() active: boolean;
   @Output() onClose = new EventEmitter();
   active$: Observable<boolean>;
+
+  /** Any game data values to set in this dialog */
+  sets$: Observable<string> = this.feature$.pipe(
+    map((f: TiledMapFeatureData) => {
+      return f.properties.sets;
+    })
+  );
 
   /** The dialog text */
   text$: Observable<string> = this.feature$.pipe(
@@ -47,4 +58,27 @@ export class DialogFeatureComponent extends TiledFeatureComponent {
       return f.properties.icon;
     })
   );
+
+  /** An optional additional icon to display for the dialog */
+  altIcon$: Observable<string> = this.feature$.pipe(
+    map((f: TiledMapFeatureData) => {
+      return f.properties.altIcon;
+    })
+  );
+
+  constructor(private store: Store<AppState>) {
+    super();
+  }
+
+  exit(object: TileObject): boolean {
+    const result = super.exit(object);
+    if (result) {
+      // Check to see if this dialog should set game key/value data
+      const sets = this.feature.properties?.sets;
+      if (sets) {
+        this.store.dispatch(new GameStateSetKeyDataAction(sets, true));
+      }
+    }
+    return result;
+  }
 }

--- a/src/app/routes/world/map/map-feature.component.ts
+++ b/src/app/routes/world/map/map-feature.component.ts
@@ -68,7 +68,7 @@ export class TiledFeatureComponent<
   feature$: Observable<TiledMapFeatureData> = this._feature$;
 
   get properties(): any {
-    return this._feature$.value ? this._feature$.value.properties || {} : {};
+    return this._feature$.value?.properties || {};
   }
 
   protected assertFeature() {

--- a/src/app/services/game-world.ts
+++ b/src/app/services/game-world.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
+import { environment } from 'environments/environment';
 import { combineLatest, Observable } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
 import { ResourceManager } from '../../game/pow-core/resource-manager';
@@ -39,9 +40,10 @@ export class GameWorld extends World {
     super();
     _sharedGameWorld = this;
     if (this.gameStateService.hasSaveGame()) {
+      if (environment.alwaysLoadSprites) {
+        this.store.dispatch(new SpritesLoadAction('assets/images/index.json'));
+      }
       this.store.dispatch(new GameStateLoadAction());
-      // this.store.dispatch(new GameDataClearAction());
-      // this.store.dispatch(new GameDataFetchAction(SPREADSHEET_ID));
     } else {
       this.store.dispatch(new SpritesLoadAction('assets/images/index.json'));
     }

--- a/src/assets/images/vehicles.json
+++ b/src/assets/images/vehicles.json
@@ -2,10 +2,30 @@
   "ship.png": {
     "width": 64,
     "height": 32,
-    "frames": 1,
+    "frames": 8,
     "source": "vehicles",
     "index": null,
     "x": 0,
-    "y": 0
+    "y": 0,
+    "cellWidth": 16,
+    "cellHeight": 16,
+    "animations": {
+      "up": {
+        "duration": 500,
+        "frames": [3, 7]
+      },
+      "right": {
+        "duration": 500,
+        "frames": [1, 5]
+      },
+      "down": {
+        "duration": 500,
+        "frames": [2, 6]
+      },
+      "left": {
+        "duration": 500,
+        "frames": [0, 4]
+      }
+    }
   }
 }

--- a/src/assets/maps/castle.tmx
+++ b/src/assets/maps/castle.tmx
@@ -38,15 +38,6 @@
     <property name="type" value="block"/>
    </properties>
   </object>
-  <object name="Guard" type="barrier" x="272" y="192" width="16" height="16">
-   <properties>
-    <property name="icon" value="guard2.png"/>
-    <property name="text" value="The Castle is closed to all but heroes of the Three Kingdoms! Prove yourself elsewhere before demanding an audience of the Suvian King!"/>
-    <property name="title" value="Guard"/>
-    <property name="type" value="barrier"/>
-    <property name="until" value="goblinDone"/>
-   </properties>
-  </object>
   <object name="Guard" type="DialogFeatureComponent" x="240" y="80" width="16" height="16">
    <properties>
     <property name="action" value="TALK"/>

--- a/src/assets/maps/fortress1.tmx
+++ b/src/assets/maps/fortress1.tmx
@@ -22,7 +22,7 @@
 9,9,9,9,33,9,9,9,9,33,9,33,9,46,46,46,46,37,46,46,46,9,9,57,57,57,57,57,
 9,9,9,9,33,9,9,9,9,33,9,33,9,46,46,46,46,46,46,9,9,9,9,57,57,57,46,46,
 9,9,9,9,33,9,9,9,9,33,9,33,9,46,46,37,33,33,33,9,33,33,9,57,37,46,46,46,
-9,9,9,9,33,9,9,9,9,33,9,33,33,33,33,33,33,17,33,24,33,33,24,46,46,46,46,46,
+9,9,9,9,33,9,9,9,9,33,9,33,33,33,33,33,33,17,33,33,33,33,24,46,46,46,46,46,
 9,9,9,9,33,9,9,9,9,33,9,9,9,46,46,37,33,33,33,9,33,33,9,57,37,46,46,46,
 9,9,9,33,33,9,9,9,9,33,9,9,9,46,46,46,46,46,46,9,9,9,9,57,57,57,46,46,
 9,9,33,33,9,9,9,33,33,33,9,9,9,46,46,46,46,37,46,46,46,9,9,57,57,57,57,57,
@@ -79,26 +79,15 @@
     <property name="id" value="fortress-wizard"/>
    </properties>
   </object>
-  <object id="6" name="Gate" type="barrier" x="304" y="240" width="16" height="16">
+  <object id="7" name="LockedGate" type="DoorFeatureComponent" x="304" y="240" width="16" height="16">
    <properties>
     <property name="icon" value="dungeonGate.png"/>
-    <property name="text" value="There is no way to slip past the heavy gate!"/>
-    <property name="title" value="Gate"/>
-    <property name="type" value="barrier"/>
-    <property name="until" value="goblinStart"/>
-   </properties>
-  </object>
-  <object id="7" name="Unlocked" type="alert" x="304" y="240" width="16" height="16">
-   <properties>
-    <property name="after" value="goblinStart"/>
-    <property name="altIcon" value="goldKey.png"/>
-    <property name="icon" value="dungeonGate.png"/>
-    <property name="sets" value="alertGoblinKey"/>
-    <property name="text" value="You use the golden key provided by the Elves to unlock the heavy gate."/>
-    <property name="title" value="Unlocked"/>
-    <property name="type" value="alert"/>
-    <property name="until" value="alertGoblinKey"/>
-    <property name="y" value="15"/>
+    <property name="id" value="goblin-fortress-front-gate"/>
+    <property name="lockedText" value="A heavy locked gate. Perhaps someone in the nearby port can help."/>
+    <property name="requiredKey" value="goblin-fortress-key"/>
+    <property name="title" value="Goblin Fortress"/>
+    <property name="unlockText" value="You use the golden key provided by the Elves to unlock the heavy gate."/>
+    <property name="until" value="goblin-fortress-front-gate"/>
    </properties>
   </object>
   <object id="8" name="fortress2" type="PortalFeatureComponent" x="48" y="48" width="16" height="16">

--- a/src/assets/maps/fortress1.tmx
+++ b/src/assets/maps/fortress1.tmx
@@ -114,6 +114,17 @@
     <property name="id" value="forstress-floor1-money"/>
    </properties>
   </object>
+  <object id="16" name="DungeonExitPortal" type="PortalFeatureComponent" x="128" y="432" width="16" height="16">
+   <properties>
+    <property name="after" value="goblin-king"/>
+    <property name="icon" value="doorway.png"/>
+    <property name="id" value="fortress-exit"/>
+    <property name="target" value="fortress1"/>
+    <property name="targetX" value="8"/>
+    <property name="targetY" value="23"/>
+    <property name="transitionType" value="fortress2"/>
+   </properties>
+  </object>
  </objectgroup>
  <objectgroup id="3" name="Zones" visible="0">
   <object id="11" name="world-plains" type="danger-zone" x="208" y="128" width="144" height="240"/>

--- a/src/assets/maps/fortress2.tmx
+++ b/src/assets/maps/fortress2.tmx
@@ -3,7 +3,7 @@
   xmlns="http://www.w3.org/1999/xhtml" version="1" orientation="orthogonal" width="25" height="25" tilewidth="16" tileheight="16">
   <properties>
     <property name="combat" value="true"></property>
-    <property name="combatZone" value="zone-dungeon"></property>
+    <property name="combatZone" value="zone-goblin-fortress"/>
   </properties>
   <tileset firstgid="1" source="tiles/environment.tsx"></tileset>
   <layer name="Terrain" width="25" height="25" opacity="1">
@@ -34,18 +34,12 @@
         <property name="type" value="encounter"></property>
       </properties>
     </object>
-    <object name="goblinKing.png" type="CombatFeatureComponent" x="128" y="368" width="16" height="16">
+    <object id="3" name="goblinKing.png" class="CombatFeatureComponent" x="128" y="368" width="16" height="16">
       <properties>
-        <property name="creatures"></property>
-        <property name="gold" value="23"></property>
-        <property name="icon" value="goblinKing.png"></property>
-        <property name="id" value="pitsKing2"></property>
-        <property name="items"></property>
-        <property name="sets" value="goblinDone"></property>
-        <property name="text" value="You face your enemy, the King of the Goblins! He is enormous and flanked by well-equipped soldiers."></property>
-        <property name="type" value="encounter"></property>
+        <property name="icon" value="goblinKing.png"/>
+        <property name="id" value="goblin-king"/>
       </properties>
-    </object>
+    </object> 
     <object name="fortress1" type="PortalFeatureComponent" x="368" y="192" width="16" height="16">
       <properties>
         <property name="icon" value="doorway.png"></property>
@@ -58,5 +52,8 @@
         <property name="y" value="12"></property>
       </properties>
     </object>
+  </objectgroup>
+  <objectgroup id="4" name="Zones">
+    <object id="5" name="zone-dungeon" class="danger-zone" x="0" y="0" width="400" height="400"/>
   </objectgroup>
 </map>

--- a/src/assets/maps/fortress2.tmx
+++ b/src/assets/maps/fortress2.tmx
@@ -2,7 +2,7 @@
 <map
   xmlns="http://www.w3.org/1999/xhtml" version="1" orientation="orthogonal" width="25" height="25" tilewidth="16" tileheight="16">
   <properties>
-    <property name="combat" value="true"></property>
+  <property name="combat" value="true"/>
     <property name="combatZone" value="zone-goblin-fortress"/>
   </properties>
   <tileset firstgid="1" source="tiles/environment.tsx"></tileset>
@@ -12,26 +12,26 @@
   <layer name="Details" width="25" height="25" opacity="1">
     <data encoding="csv">0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,6,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,6,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,6,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,6,0,0,0,0,0,6,0,0,0,0,0,6,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,24,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,21,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,20,0,0,0,0,0,0,0,0,17,0,17,0,0,0,0,0,0,0,0,0,0,0,0,0,20,0,0,0,0,0,24,0,0,0,0,0,0,0,0,0,0,0,6,0,0,0,0,0,0,20,0,0,0,0,0,0,0,0,17,0,17,0,0,0,0,0,0,0,0,0,0,0,0,0,20,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,19,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0</data>
   </layer>
-  <objectgroup name="Features" width="25" height="25" opacity="1">
-    <object name="goblinArcher.png" type="CombatFeatureComponent" x="256" y="48" width="16" height="16">
+ <objectgroup id="3" name="Features">
+  <object id="1" name="goblinArcher.png" type="CombatFeatureComponent" x="256" y="48" width="16" height="16">
       <properties>
-        <property name="creatures"></property>
-        <property name="icon" value="goblinArcher.png"></property>
-        <property name="id" value="goblin-archers"></property>
-        <property name="items"></property>
-        <property name="type" value="encounter"></property>
+    <property name="creatures" value=""/>
+    <property name="icon" value="goblinArcher.png"/>
+    <property name="id" value="goblin-archers"/>
+    <property name="items" value=""/>
+    <property name="type" value="encounter"/>
       </properties>
     </object>
-    <object name="chest.png" type="CombatFeatureComponent" x="288" y="320" width="16" height="16">
+  <object id="2" name="chest.png" type="CombatFeatureComponent" x="288" y="320" width="16" height="16">
       <properties>
-        <property name="ambushed" value="true"></property>
-        <property name="creatures"></property>
-        <property name="gold" value="15"></property>
-        <property name="icon" value="chest.png"></property>
-        <property name="id" value="goblinPotion"></property>
-        <property name="items"></property>
-        <property name="text" value="You find here a small cache of potions."></property>
-        <property name="type" value="encounter"></property>
+    <property name="ambushed" value="true"/>
+    <property name="creatures" value=""/>
+    <property name="gold" value="15"/>
+    <property name="icon" value="chest.png"/>
+    <property name="id" value="goblinPotion"/>
+    <property name="items" value=""/>
+    <property name="text" value="You find here a small cache of potions."/>
+    <property name="type" value="encounter"/>
       </properties>
     </object>
     <object id="3" name="goblinKing.png" class="CombatFeatureComponent" x="128" y="368" width="16" height="16">
@@ -40,20 +40,31 @@
         <property name="id" value="goblin-king"/>
       </properties>
     </object> 
-    <object name="fortress1" type="PortalFeatureComponent" x="368" y="192" width="16" height="16">
+  <object id="3" name="fortress1" type="PortalFeatureComponent" x="368" y="192" width="16" height="16">
+   <properties>
+    <property name="icon" value="doorway.png"/>
+    <property name="target" value="fortress1"/>
+    <property name="targetX" value="3"/>
+    <property name="targetY" value="3"/>
+    <property name="text" value="Return to the lower level of the fortess?"/>
+    <property name="transitionType" value="down"/>
+    <property name="type" value="transition"/>
+    <property name="y" value="12"/>
+   </properties>
+  </object>
+  <object id="5" name="DungeonExitPortal" type="PortalFeatureComponent" x="128" y="368" width="16" height="16">
       <properties>
-        <property name="icon" value="doorway.png"></property>
-        <property name="target" value="fortress1"></property>
-        <property name="targetX" value="3"></property>
-        <property name="targetY" value="3"></property>
-        <property name="text" value="Return to the lower level of the fortess?"></property>
-        <property name="transitionType" value="down"></property>
-        <property name="type" value="transition"></property>
-        <property name="y" value="12"></property>
+    <property name="after" value="goblin-king"/>
+    <property name="icon" value="doorway.png"/>
+    <property name="id" value="fortress-exit"/>
+    <property name="target" value="fortress1"/>
+    <property name="targetX" value="8"/>
+    <property name="targetY" value="27"/>
+    <property name="transitionType" value="town"/>
       </properties>
     </object>
   </objectgroup>
-  <objectgroup id="4" name="Zones">
+ <objectgroup id="4" name="Zones" visible="0">
     <object id="5" name="zone-dungeon" class="danger-zone" x="0" y="0" width="400" height="400"/>
   </objectgroup>
 </map>

--- a/src/assets/maps/port.tmx
+++ b/src/assets/maps/port.tmx
@@ -90,52 +90,48 @@
     <property name="text" value="We are struggling under the weight of endless Goblin assaults! It is believed that a powerful and ambitious Goblin King in the Eastern edge of the forest is behind the attacks."/>
     <property name="title" value="Elvish Elder"/>
     <property name="type" value="sign"/>
-    <property name="until" value="goblinDone"/>
+    <property name="until" value="goblin-king"/>
    </properties>
   </object>
   <object name="Elvish Elder" type="DialogFeatureComponent" x="256" y="272" width="16" height="16">
    <properties>
     <property name="action" value="TALK"/>
-    <property name="after" value="goblinDone"/>
+    <property name="after" value="goblin-king"/>
     <property name="icon" value="gnome2.png"/>
     <property name="text" value="Tales of your heroism will be sung by the Elvish people for all of eternity! Now sail the Wandering Sea and discover if even greater deeds await you."/>
     <property name="title" value="Elvish Elder"/>
     <property name="type" value="sign"/>
    </properties>
   </object>
-  <object name="Elvish Councillor" type="dispatch" x="240" y="272" width="16" height="16">
+  <object name="Elvish Councillor" type="DialogFeatureComponent" x="240" y="272" width="16" height="16">
    <properties>
-    <property name="action" value="TALK"/>
     <property name="altIcon" value="goldKey.png"/>
     <property name="icon" value="gnomeKing.png"/>
-    <property name="sets" value=""/>
+    <property name="sets" value="goblin-fortress-key"/>
     <property name="text" value="Welcome, heroes of Bryarlake. The Goblin King in the fortress in the eastern edge of the forest must be stopped! Will you take this key, sneak into the fortress, and defeat the king?"/>
     <property name="title" value="Elvish Councillor"/>
-    <property name="type" value="dispatch"/>
-    <property name="until" value="goblinStart"/>
+    <property name="until" value="goblin-fortress-key"/>
+   </properties>
+  </object>
+  <object name="Elvish Councillor" type="DialogFeatureComponent" x="240" y="272" width="16" height="16">
+   <properties>
+    <property name="after" value="goblin-fortress-key"/>
+    <property name="icon" value="gnomeKing.png"/>
+    <property name="text" value="Please make haste to defeat the Goblin King in his fortress at the eastern extent of Nothian Forest!"/>
+    <property name="title" value="Elvish Councillor"/>
+    <property name="type" value="sign"/>
+    <property name="until" value="goblin-king"/>
    </properties>
   </object>
   <object name="Elvish Councillor" type="DialogFeatureComponent" x="240" y="272" width="16" height="16">
    <properties>
     <property name="action" value="TALK"/>
-    <property name="after" value="goblinStart"/>
-    <property name="icon" value="gnomeKing.png"/>
-    <property name="text" value="Please make haste to defeat the Goblin King in his fortress at the eastern extent of Nothian Forest!"/>
-    <property name="title" value="Elvish Councillor"/>
-    <property name="type" value="sign"/>
-    <property name="until" value="goblinDone"/>
-   </properties>
-  </object>
-  <object name="Elvish Councillor" type="dispatch" x="240" y="272" width="16" height="16">
-   <properties>
-    <property name="action" value="TALK"/>
-    <property name="after" value="goblinDone"/>
+    <property name="after" value="goblin-king"/>
     <property name="altIcon" value="rolledScroll.png"/>
     <property name="icon" value="gnomeKing.png"/>
     <property name="sets" value="castleStart"/>
     <property name="text" value="Your brave acts are enough for many lifetimes, yet we urge you to take this scroll by sea to the Great Suvian Desert, where the proud people of Castle Bashgar are in great danger. A boat is prepared for you outside the city, will you go?"/>
     <property name="title" value="Elvish Councillor"/>
-    <property name="type" value="dispatch"/>
     <property name="until" value="castleStart"/>
    </properties>
   </object>
@@ -160,14 +156,13 @@
     <property name="type" value="sign"/>
    </properties>
   </object>
-  <object name="chest.png" type="CombatFeatureComponent" x="240" y="256" width="16" height="16">
+  <object name="chest.png" type="TreasureFeatureComponent" x="240" y="256" width="16" height="16">
    <properties>
-    <property name="after" value="goblinDone"/>
+    <property name="after" value="goblin-king"/>
     <property name="creatures" value=""/>
-    <property name="gold" value="35"/>
+    <property name="gold" value="75"/>
     <property name="icon" value="chest.png"/>
-    <property name="id" value="goblinReward"/>
-    <property name="items" value=""/>
+    <property name="id" value="goblin-reward"/>
     <property name="text" value="The elves reward you for your defeat of the Goblin King!"/>
    </properties>
   </object>

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: true,
   useDevTools: false,
+  alwaysLoadSprites: false,
 };

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,3 +1,4 @@
 export const environment = {
   production: true,
+  useDevTools: false,
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,7 +4,10 @@
 
 export const environment = {
   production: false,
+  /** Add support for redux devtools extension when true */
   useDevTools: true,
+  /** Force refetching of sprite sheet metadata even when it's already present in a save file */
+  alwaysLoadSprites: true,
 };
 
 /*

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,6 +4,7 @@
 
 export const environment = {
   production: false,
+  useDevTools: true,
 };
 
 /*

--- a/src/game/pow-core/resources/tiled/tiled.model.ts
+++ b/src/game/pow-core/resources/tiled/tiled.model.ts
@@ -31,6 +31,7 @@ export interface ITiledObject<PropertiesType = any> extends ITiledBase {
   type?: string;
   gid?: number;
   color?: string;
+  sets?: string;
 }
 
 export interface ITileSetDependency {


### PR DESCRIPTION
The goblin fortress quest was broken because of... reasons. This fixes it up so that you can help out the port people and unlock something fun at the end.

Changes
--- 

 - fix ship animations and the goblin-fortress -> port town quest.
 - reenable redux-devtools for developer experience, but disable by default in production. use `useDevTools` in `environment.ts` or the prod counterpart to change this behavior. setting this to false in development may speed up performance if you have issues on older phone devices.
 - add `alwaysLoadSprites` boolean to environment that allows forcing the game to reload sprite sheet metadata, even if there's already a cached copy in the save file for a game. Useful in development when you want to update the sprites without deleting your save game.
