### PR TITLE
Feat/show store upgrades

### DIFF
--- a/src/app/models/game-data/game-data.model.ts
+++ b/src/app/models/game-data/game-data.model.ts
@@ -13,6 +13,22 @@ export type ItemGroups = 'default' | 'rare' | 'magic';
 
 export type ItemElements = 'holy' | 'water' | 'wind' | 'heal';
 
+/** Array of valid equipment slot names on a party member */
+export const EQUIPMENT_SLOTS = [
+  'armor',
+  'helm',
+  'boots',
+  'shield',
+  'accessory',
+  'weapon',
+  'spell',
+] as const;
+
+/** Valid equipment slot strings type */
+export type EquipmentSlotTypes = typeof EQUIPMENT_SLOTS[number];
+
+export type ItemWeaponType = 'weapon';
+
 export type ItemArmorType = 'armor' | 'helm' | 'boots' | 'shield' | 'accessory';
 
 export interface ITemplateId {
@@ -67,7 +83,7 @@ export interface ITemplateItem extends ITemplateBaseItem {
 }
 
 export interface ITemplateWeapon extends ITemplateBaseItem {
-  readonly type: 'weapon';
+  readonly type: ItemWeaponType;
   /**
    * The attack value for this weapon.
    */

--- a/src/app/models/selectors.ts
+++ b/src/app/models/selectors.ts
@@ -214,3 +214,28 @@ export const getGameInventory = createSelector(
       .toList();
   }
 );
+
+/** Get game Party with equipment objects resolved */
+export const getGamePartyWithEquipment = createSelector(
+  getGameParty,
+  getEntityItemById,
+  (party: Immutable.List<Entity>, items: Immutable.Map<string, EntityItemTypes>) => {
+    return party
+      .map((entity) => {
+        if (!entity) {
+          return null;
+        }
+        const result: Partial<EntityWithEquipment> = {
+          armor: items.get(entity.armor) as ITemplateArmor,
+          helm: items.get(entity.helm) as ITemplateArmor,
+          shield: items.get(entity.shield) as ITemplateArmor,
+          accessory: items.get(entity.accessory) as ITemplateArmor,
+          boots: items.get(entity.boots) as ITemplateArmor,
+          weapon: items.get(entity.weapon) as ITemplateWeapon,
+        };
+        return Object.assign({}, entity, result) as EntityWithEquipment;
+      })
+      .filter((r) => r !== null)
+      .toList();
+  }
+);

--- a/src/app/routes/world/map/features/store-feature.component.html
+++ b/src/app/routes/world/map/features/store-feature.component.html
@@ -40,12 +40,31 @@
         mat-row
         class="item-value"
         *matRowDef="let row; columns: ['icon', 'value']"
-        (click)="toggleRowSelection(row)"
+        (click)="toggleRowSelection($event, row)"
         [class.selected]="(selected$ | async).has(row)"
       ></tr>
     </table>
     <h1 *ngIf="!(inventory$ | async).length">No Items</h1>
   </div>
+
+  <section class="differences">
+    <div *ngFor="let diff of differences$ | async; trackBy: trackByEid">
+      <rpg-sprite
+        [class.disabled]="
+          diff.diff == '' && !(selling$ | async) && (selected$ | async).size > 0
+        "
+        class="image"
+        [name]="diff.member.icon"
+        frame="7"
+      ></rpg-sprite>
+      <strong
+        *ngIf="diff.diff != '' && !(selling$ | async)"
+        [class.upgrade]="diff.difference > 0"
+        [class.downgrade]="diff.difference < 0"
+        >{{ diff.diff }}</strong
+      >
+    </div>
+  </section>
 
   <footer class="actions">
     <button mat-raised-button (click)="close()" color="primary">Exit</button>

--- a/src/app/routes/world/map/features/store-feature.component.scss
+++ b/src/app/routes/world/map/features/store-feature.component.scss
@@ -8,6 +8,7 @@
   @include pow-dialog();
   color: white;
   display: block;
+  user-select: none;
   h1 {
     margin: auto;
   }
@@ -17,6 +18,33 @@
     position: relative;
     margin-bottom: 0;
     padding-bottom: 15px;
+  }
+  .differences {
+    height: 80px;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-around;
+    > div {
+      position: relative;
+      padding-top: 15px;
+      rpg-sprite {
+        display: block;
+        &.disabled {
+          opacity: 0.4;
+        }
+      }
+      > strong {
+        position: absolute;
+        right: -10px;
+        top: 0px;
+        &.upgrade {
+          color: $gameGold;
+        }
+        &.downgrade {
+          color: #ab3c3c;
+        }
+      }
+    }
   }
 
   .inventory {

--- a/src/app/routes/world/map/features/store-feature.component.scss
+++ b/src/app/routes/world/map/features/store-feature.component.scss
@@ -6,6 +6,7 @@
   min-width: 320px;
   z-index: $zCanvasGui;
   @include pow-dialog();
+  overflow-y: auto;
   color: white;
   display: block;
   user-select: none;
@@ -99,6 +100,18 @@
       span {
         margin-left: 4px;
       }
+    }
+  }
+
+  // Fit dialog to full screen and remove margins
+  @media (max-height: 600px) {
+    font-size: inherit;
+    // margin: 0;
+    padding: 4px;
+    max-height: 100%;
+    box-sizing: border-box;
+    .title {
+      padding: 4px;
     }
   }
 }

--- a/src/app/routes/world/map/features/store-feature.component.ts
+++ b/src/app/routes/world/map/features/store-feature.component.ts
@@ -287,7 +287,7 @@ export abstract class StoreFeatureComponent extends TiledFeatureComponent {
             } else if (r.difference < 0) {
               r.diff = `-${r.difference}`;
             } else {
-              r.diff = '0';
+              r.diff = '=';
             }
           }
           return r;

--- a/src/app/routes/world/map/features/store-feature.component.ts
+++ b/src/app/routes/world/map/features/store-feature.component.ts
@@ -250,15 +250,32 @@ export abstract class StoreFeatureComponent extends TiledFeatureComponent {
               // Only compare items we can wield
               const usedBy = compareItem.usedby || [];
               if (usedBy.indexOf(pm.type) !== -1 || usedBy.length === 0) {
-                if (pm.weapon && weapon.attack !== undefined) {
-                  return { member: pm, difference: weapon.attack - pm.weapon.attack };
-                } else if (pm[armor.type] && armor.defense !== undefined) {
+                if (weapon.attack !== undefined) {
+                  // Compare to current weapon
+                  if (pm.weapon) {
+                    return { member: pm, difference: weapon.attack - pm.weapon.attack };
+                  }
+                  // Has no current weapon
                   return {
                     member: pm,
-                    difference: armor.defense - pm[armor.type].defense,
+                    difference: weapon.attack,
+                  };
+                } else if (armor.defense !== undefined) {
+                  // Compare to current armor piece
+                  if (pm[armor.type]) {
+                    return {
+                      member: pm,
+                      difference: armor.defense - pm[armor.type].defense,
+                    };
+                  }
+                  // Has no current armor piece
+                  return {
+                    member: pm,
+                    difference: armor.defense,
                   };
                 }
               }
+              // Cannot be equipped
               return { member: pm, difference: 0, diff: '' };
             })
             .toJS();


### PR DESCRIPTION
This improves the usability of stores, so it's easier to tell which equipment is better than what you have and equip newly purchased items. It also updates the equipment screen to only show items your current character can equip.

**Before**
![image](https://user-images.githubusercontent.com/101493/198410659-b2f8fd63-242b-4e52-8766-02251f800cae.png)

**After**
![image](https://user-images.githubusercontent.com/101493/198410676-fef12b68-4ca5-4aaf-ba42-c7507ccc19cb.png)


When you purchase a single equipable item, it will be automatically equipped in the slot of the supported player. If there is an existing item in that slot, it will be unequipped.
![image](https://user-images.githubusercontent.com/101493/198411026-193b4dfa-d4b4-42a0-9464-6364806766ef.png)

