### PR TITLE
Add limited visibility for "dark" maps

### DIFF
--- a/src/app/models/game-data/random-encounters.ts
+++ b/src/app/models/game-data/random-encounters.ts
@@ -54,12 +54,12 @@ export const RANDOM_ENCOUNTERS_DATA: ITemplateRandomEncounter[] = [
   },
   {
     id: 'world-fortress-archer',
-    zones: ['zone-goblin-fortress'],
+    zones: ['zone-dungeon'],
     enemies: ['goblin-archer', 'goblin-archer'],
   },
   {
     id: 'world-fortress-spear',
-    zones: ['zone-goblin-fortress'],
+    zones: ['zone-dungeon'],
     enemies: ['goblin-spear', 'goblin'],
   },
 ];

--- a/src/app/routes/world/behaviors/combat-encounter.behavior.ts
+++ b/src/app/routes/world/behaviors/combat-encounter.behavior.ts
@@ -56,8 +56,8 @@ export class CombatEncounterBehaviorComponent extends SceneObjectBehavior {
     if (!this.tileMap) {
       return;
     }
-    const map = this.tileMap.map;
-    if (!map || !map.properties || !map.properties.combat) {
+    const zone: IZoneMatch = this.tileMap.getCombatZones(move.to);
+    if (!zone) {
       return;
     }
     const terrain = this.tileMap.getTerrain('Terrain', move.to.x, move.to.y);

--- a/src/app/routes/world/behaviors/player-camera.behavior.ts
+++ b/src/app/routes/world/behaviors/player-camera.behavior.ts
@@ -36,6 +36,7 @@ export class PlayerCameraBehaviorComponent extends CameraBehavior {
 
     // Center on player object
     view.camera.setCenter(this.host.renderPoint || this.host.point);
+    view.focusPoint.set(this.host.renderPoint || this.host.point);
 
     // Clamp to tile map if it is present.
     if (this.host.tileMap) {

--- a/src/app/routes/world/map/world-map.entity.ts
+++ b/src/app/routes/world/map/world-map.entity.ts
@@ -34,6 +34,7 @@ import { Scene } from '../../../scene/scene';
 import { SceneView } from '../../../scene/scene-view';
 import { ISceneViewRenderer } from '../../../scene/scene.model';
 import { TileMap } from '../../../scene/tile-map';
+import { GameWorld } from '../../../services/game-world';
 import { MapFeatureInputBehaviorComponent } from '../behaviors/map-feature-input.behavior';
 import { MapFeatureComponent, TiledMapFeatureData } from './map-feature.component';
 import { WorldPlayerComponent } from './world-player.entity';
@@ -124,7 +125,8 @@ export class WorldMapComponent
     public gameStateService: GameStateService,
     public store: Store<AppState>,
     public loadingService: LoadingService,
-    public loader: ResourceManager
+    public loader: ResourceManager,
+    public world: GameWorld
   ) {
     super();
   }
@@ -159,6 +161,11 @@ export class WorldMapComponent
     this._subscriptions.forEach((s) => s.unsubscribe());
     this._subscriptions.length = 0;
     this.destroy();
+  }
+
+  loaded() {
+    super.loaded();
+    this.world.setMusic(this.musicUrl);
   }
 
   //

--- a/src/app/routes/world/world.component.ts
+++ b/src/app/routes/world/world.component.ts
@@ -124,7 +124,7 @@ export class WorldComponent extends SceneView implements AfterViewInit, OnDestro
   //
   onAddToScene(scene: Scene) {
     super.onAddToScene(scene);
-    this.mouse = this.world.input.mouseHook(<SceneView>this, 'world');
+    this.mouse = this.world.input.mouseHook(this, 'world');
 
     //
     // TODO: Consider how to remove these event listeners and replace with strongly typed observables

--- a/src/app/scene/scene-view.ts
+++ b/src/app/scene/scene-view.ts
@@ -15,7 +15,7 @@
  */
 import * as _ from 'underscore';
 import { CameraBehavior } from '../behaviors/camera-behavior';
-import { IRect, Point, Rect } from '../core';
+import { Point, Rect } from '../core';
 import { TileMapRenderer } from './render/tile-map-renderer';
 import { Scene } from './scene';
 import { SceneObject } from './scene-object';
@@ -112,25 +112,6 @@ export class SceneView extends SceneObject implements ISceneView {
     const clipGrow = this.camera.clone();
     clipGrow.point.round();
     clipGrow.extent.round();
-
-    // Clamp to tilemap bounds.
-    const rect: IRect = this.map.bounds;
-    if (clipGrow.point.x < rect.point.x) {
-      // NOTE: -1 here because the rendering is offset by half a tile (center origin)
-      clipGrow.point.x += rect.point.x - 1 - clipGrow.point.x;
-    }
-    if (clipGrow.point.y < rect.point.y) {
-      // NOTE: -1 here because the rendering is offset by half a tile (center origin)
-      clipGrow.point.y += rect.point.y - 1 - clipGrow.point.y;
-    }
-    if (clipGrow.point.x + clipGrow.extent.x > rect.point.x + rect.extent.x) {
-      clipGrow.point.x -=
-        clipGrow.point.x + clipGrow.extent.x - (rect.point.x + rect.extent.x);
-    }
-    if (clipGrow.point.y + clipGrow.extent.y > rect.point.y + rect.extent.y) {
-      clipGrow.point.y -=
-        clipGrow.point.y + clipGrow.extent.y - (rect.point.y + rect.extent.y);
-    }
     return clipGrow;
   }
 

--- a/src/app/scene/scene-view.ts
+++ b/src/app/scene/scene-view.ts
@@ -43,6 +43,8 @@ export class SceneView extends SceneObject implements ISceneView {
   scene: Scene = null;
   mapRenderer: TileMapRenderer = new TileMapRenderer();
   map: TileMap;
+  /** Tell the view where the player is at. Useful for rendering. */
+  focusPoint: Point = new Point();
 
   get canvas(): HTMLCanvasElement {
     return this._canvas;
@@ -114,10 +116,12 @@ export class SceneView extends SceneObject implements ISceneView {
     // Clamp to tilemap bounds.
     const rect: IRect = this.map.bounds;
     if (clipGrow.point.x < rect.point.x) {
-      clipGrow.point.x += rect.point.x - clipGrow.point.x;
+      // NOTE: -1 here because the rendering is offset by half a tile (center origin)
+      clipGrow.point.x += rect.point.x - 1 - clipGrow.point.x;
     }
     if (clipGrow.point.y < rect.point.y) {
-      clipGrow.point.y += rect.point.y - clipGrow.point.y;
+      // NOTE: -1 here because the rendering is offset by half a tile (center origin)
+      clipGrow.point.y += rect.point.y - 1 - clipGrow.point.y;
     }
     if (clipGrow.point.x + clipGrow.extent.x > rect.point.x + rect.extent.x) {
       clipGrow.point.x -=
@@ -168,6 +172,27 @@ export class SceneView extends SceneObject implements ISceneView {
 
   // Render post effects
   renderPost() {
+    const clip = this.worldToScreen(this.getCameraClip());
+    const center = this.worldToScreen(this.focusPoint);
+
+    if (this.map.dark) {
+      this.context.rect(clip.point.x, clip.point.y, clip.extent.x, clip.extent.y);
+      // create radial gradient
+      const outerRadius = 100;
+      const innerRadius = 10;
+      const gradient = this.context.createRadialGradient(
+        center.x,
+        center.y,
+        innerRadius,
+        center.x,
+        center.y,
+        outerRadius
+      );
+      gradient.addColorStop(0, 'rgba(0,0,0,0)');
+      gradient.addColorStop(1, 'rgba(0,0,0,1)');
+      this.context.fillStyle = gradient;
+      this.context.fill();
+    }
     // nothing
   }
 

--- a/src/app/scene/tile-map.ts
+++ b/src/app/scene/tile-map.ts
@@ -38,6 +38,14 @@ export class TileMap extends SceneObject {
   zones?: ITiledLayer;
   bounds: Rect = new Rect(0, 0, 10, 10);
   dirtyLayers: boolean = false;
+  /**
+   * Whether this map should render with a limited visibilty vignette
+   */
+  dark: boolean = false;
+  /**
+   * The URL of a music track to play while this map is loaded. Specified
+   * by the "music" custom property on a Tiled map.
+   */
   musicUrl: string;
   private _loaded: boolean = false;
 
@@ -60,6 +68,10 @@ export class TileMap extends SceneObject {
     this.musicUrl = '';
     if (this.map?.properties?.music) {
       this.musicUrl = this.map.properties.music;
+    }
+    this.dark = false;
+    if (this.map?.properties?.dark) {
+      this.dark = true;
     }
 
     this._loaded = true;

--- a/src/app/scene/tile-map.ts
+++ b/src/app/scene/tile-map.ts
@@ -74,7 +74,7 @@ export class TileMap extends SceneObject {
   }
 
   setMap(map: TiledTMXResource) {
-    if (!map /* || !map.isReady() */) {
+    if (!map /* || !map.isReady() */ || this.map?.url === map.url) {
       return false;
     }
     if (this.map) {

--- a/src/assets/maps/crypt.tmx
+++ b/src/assets/maps/crypt.tmx
@@ -2,6 +2,7 @@
 <map version="1.9" tiledversion="1.9.2" orientation="orthogonal" renderorder="right-down" width="25" height="39" tilewidth="16" tileheight="16" infinite="0" nextlayerid="4" nextobjectid="17">
  <properties>
   <property name="combat" type="bool" value="true"/>
+  <property name="dark" type="bool" value="true"/>
  </properties>
  <tileset firstgid="1" source="tiles/environment.tsx"/>
  <tileset firstgid="72" source="tiles/objects.tsx"/>

--- a/src/assets/maps/fortress1.tmx
+++ b/src/assets/maps/fortress1.tmx
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.9" tiledversion="1.9.2" orientation="orthogonal" renderorder="right-down" width="28" height="31" tilewidth="16" tileheight="16" infinite="0" nextlayerid="4" nextobjectid="15">
- <properties>
-  <property name="combat" value="true"/>
-  <property name="combatZone" value="zone-goblin-fortress"/>
- </properties>
  <tileset firstgid="1" source="tiles/environment.tsx"/>
  <tileset firstgid="72" source="tiles/objects.tsx"/>
  <tileset firstgid="98" source="tiles/creatures.tsx"/>
@@ -115,7 +111,7 @@
  <objectgroup id="3" name="Zones" visible="0">
   <object id="14" name="main" class="CombatZoneClass" x="1" y="1" width="366.5" height="495">
    <properties>
-    <property name="zone" propertytype="DataRandomEncounters" value="zone-goblin-fortress"/>
+    <property name="zone" propertytype="DataRandomEncounters" value="zone-dungeon"/>
    </properties>
   </object>
  </objectgroup>

--- a/src/assets/maps/fortress2.tmx
+++ b/src/assets/maps/fortress2.tmx
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.9" tiledversion="1.9.2" orientation="orthogonal" renderorder="right-down" width="25" height="25" tilewidth="16" tileheight="16" infinite="0" nextlayerid="3" nextobjectid="1">
  <properties>
-  <property name="combat" value="true"/>
-  <property name="combatZone" value="zone-goblin-fortress"/>
+  <property name="dark" type="bool" value="true"/>
  </properties>
  <tileset firstgid="1" source="tiles/environment.tsx"/>
  <tileset firstgid="72" source="tiles/creatures.tsx"/>
@@ -112,9 +111,9 @@
   </object>
  </objectgroup>
  <objectgroup id="4" name="Zones" visible="0">
-  <object id="5" name="zone-dungeon" class="CombatZoneClass" x="0" y="0" width="400" height="400">
+  <object id="5" name="main" class="CombatZoneClass" x="0" y="0" width="400" height="400">
    <properties>
-    <property name="zone" propertytype="DataRandomEncounters" value="zone-goblin-fortress"/>
+    <property name="zone" propertytype="DataRandomEncounters" value="zone-dungeon"/>
    </properties>
   </object>
  </objectgroup>

--- a/src/assets/maps/lair.tmx
+++ b/src/assets/maps/lair.tmx
@@ -2,6 +2,7 @@
 <map version="1.9" tiledversion="1.9.2" orientation="orthogonal" renderorder="right-down" width="29" height="51" tilewidth="16" tileheight="16" infinite="0" nextlayerid="3" nextobjectid="9">
  <properties>
   <property name="combat" value="true"/>
+  <property name="dark" type="bool" value="true"/>
  </properties>
  <tileset firstgid="1" source="tiles/environment.tsx"/>
  <tileset firstgid="72" source="tiles/creatures.tsx"/>

--- a/src/assets/maps/sewer.tmx
+++ b/src/assets/maps/sewer.tmx
@@ -3,6 +3,7 @@
  <properties>
   <property name="combat" value="true"/>
   <property name="combatZone" value="zone-sewer"/>
+  <property name="dark" type="bool" value="true"/>
  </properties>
  <tileset firstgid="1" source="tiles/environment.tsx"/>
  <tileset firstgid="72" source="tiles/objects.tsx"/>


### PR DESCRIPTION
Some maps are supposed to be hard to explore, but with the current game you can see everything around you, so it's too easy to know which way to go. Add a "dark" property to maps that renders a vignette that limits visibility.

**before**
![image](https://user-images.githubusercontent.com/101493/198841954-d38005f0-385b-4f8a-8463-bd98a8d6a213.png)

**after**
![image](https://user-images.githubusercontent.com/101493/198841963-cc1d24b5-4966-484b-a97e-e8e2d11a95cc.png)
