### PR TITLE
Fix strict typescript PR regressions

### DIFF
--- a/src/app/models/game-data/armors.ts
+++ b/src/app/models/game-data/armors.ts
@@ -175,10 +175,6 @@ export const ARMOR_DATA: ITemplateArmor[] = [
 ];
 
 /** Get an armor descriptor given its id value */
-export function getArmorById(id: string): ITemplateArmor {
-  const template = ARMOR_DATA.find((item) => item.id === id);
-  if (!template) {
-    throw new Error(`getArmorById: invalid template id ${id}`);
-  }
-  return template;
+export function getArmorById(id: string): ITemplateArmor | null {
+  return ARMOR_DATA.find((item) => item.id === id) || null;
 }

--- a/src/app/models/game-data/enemies.ts
+++ b/src/app/models/game-data/enemies.ts
@@ -238,10 +238,6 @@ export const ENEMIES_DATA: ITemplateEnemy[] = [
 ];
 
 /** Get an enemy descriptor given its id value */
-export function getEnemyById(id: string): ITemplateEnemy {
-  const template = ENEMIES_DATA.find((item) => item.id === id);
-  if (!template) {
-    throw new Error(`getEnemyById: invalid template id ${id}`);
-  }
-  return template;
+export function getEnemyById(id: string): ITemplateEnemy | null {
+  return ENEMIES_DATA.find((item) => item.id === id) || null;
 }

--- a/src/app/models/game-data/fixed-encounters.ts
+++ b/src/app/models/game-data/fixed-encounters.ts
@@ -110,10 +110,6 @@ export const FIXED_ENCOUNTERS_DATA: ITemplateFixedEncounter[] = [
 ];
 
 /** Get a fixed encounter descriptor given its id value */
-export function getFixedEncounterById(id: string): ITemplateFixedEncounter {
-  const template = FIXED_ENCOUNTERS_DATA.find((item) => item.id === id);
-  if (!template) {
-    throw new Error(`getFixedEncounterById: invalid template id ${id}`);
-  }
-  return template;
+export function getFixedEncounterById(id: string): ITemplateFixedEncounter | null {
+  return FIXED_ENCOUNTERS_DATA.find((item) => item.id === id) || null;
 }

--- a/src/app/models/game-data/items.ts
+++ b/src/app/models/game-data/items.ts
@@ -32,10 +32,6 @@ export const ITEMS_DATA: ITemplateItem[] = [
 ];
 
 /** Get an item descriptor given its id value */
-export function getItemById(id: string): ITemplateItem {
-  const template = ITEMS_DATA.find((item) => item.id === id);
-  if (!template) {
-    throw new Error(`getItemById: invalid template id ${id}`);
-  }
-  return template;
+export function getItemById(id: string): ITemplateItem | null {
+  return ITEMS_DATA.find((item) => item.id === id) || null;
 }

--- a/src/app/models/game-data/magic.ts
+++ b/src/app/models/game-data/magic.ts
@@ -38,10 +38,6 @@ export const MAGIC_DATA: ITemplateMagic[] = [
 ];
 
 /** Get a magic descriptor given its id value */
-export function getMagicById(id: string): ITemplateMagic {
-  const template = MAGIC_DATA.find((item) => item.id === id);
-  if (!template) {
-    throw new Error(`getMagicById: invalid template id ${id}`);
-  }
-  return template;
+export function getMagicById(id: string): ITemplateMagic | null {
+  return MAGIC_DATA.find((item) => item.id === id) || null;
 }

--- a/src/app/models/game-data/random-encounters.ts
+++ b/src/app/models/game-data/random-encounters.ts
@@ -65,10 +65,6 @@ export const RANDOM_ENCOUNTERS_DATA: ITemplateRandomEncounter[] = [
 ];
 
 /** Get a random encounter descriptor given its id value */
-export function getRandomEncounterById(id: string): ITemplateRandomEncounter {
-  const template = RANDOM_ENCOUNTERS_DATA.find((item) => item.id === id);
-  if (!template) {
-    throw new Error(`getRandomEncounterById: invalid template id ${id}`);
-  }
-  return template;
+export function getRandomEncounterById(id: string): ITemplateRandomEncounter | null {
+  return RANDOM_ENCOUNTERS_DATA.find((item) => item.id === id) || null;
 }

--- a/src/app/models/game-data/weapons.ts
+++ b/src/app/models/game-data/weapons.ts
@@ -234,10 +234,6 @@ export const WEAPONS_DATA: ITemplateWeapon[] = [
   },
 ];
 /** Get a weapon descriptor given its id value */
-export function getWeaponById(id: string): ITemplateWeapon {
-  const template = WEAPONS_DATA.find((item) => item.id === id);
-  if (!template) {
-    throw new Error(`getWeaponById: invalid template id ${id}`);
-  }
-  return template;
+export function getWeaponById(id: string): ITemplateWeapon | null {
+  return WEAPONS_DATA.find((item) => item.id === id) || null;
 }

--- a/src/app/routes/world/map/features/combat-feature.component.ts
+++ b/src/app/routes/world/map/features/combat-feature.component.ts
@@ -86,7 +86,7 @@ export class CombatFeatureComponent extends TiledFeatureComponent {
       .select(getGameParty)
       .pipe(
         map((party: Immutable.List<Entity>) => {
-          const encounter: ITemplateFixedEncounter = getFixedEncounterById(
+          const encounter: ITemplateFixedEncounter | null = getFixedEncounterById(
             this.properties.id
           );
 

--- a/src/app/routes/world/map/world-player.entity.ts
+++ b/src/app/routes/world/map/world-player.entity.ts
@@ -108,8 +108,8 @@ export class WorldPlayerComponent
       event.findBehavior(TiledFeatureComponent);
     if (feature) {
       feature.exit(this);
-      this.feature = null;
     }
+    this.feature = null;
   }
 
   private _featureComponent$ = new BehaviorSubject<TiledFeatureComponent | null>(null);

--- a/src/app/services/rpg-game.ts
+++ b/src/app/services/rpg-game.ts
@@ -109,7 +109,7 @@ export class RPGGame {
 
   giveItemToPlayer(
     player: IPartyMember,
-    templateItem: ITemplateBaseItem,
+    templateItem: ITemplateBaseItem | null,
     equipSlot: keyof EntitySlots
   ) {
     if (!templateItem) {


### PR DESCRIPTION
- using chests that had non-item rewards was broken by an assertion that all items looked up had to exist or an error was raised.
- pressing escape to open/close the menu didn't work after interacting with a game feature tile