### PR TITLE
fix(sprites): floor render coords to avoid bleeding

### DIFF
--- a/src/app/scene/render/tile-object-renderer.ts
+++ b/src/app/scene/render/tile-object-renderer.ts
@@ -48,12 +48,10 @@ export class TileObjectRenderer {
       sourceWidth = object.meta.cellWidth;
       sourceHeight = object.meta.cellHeight;
     }
-    const objWidth = view.fastScreenToWorldNumber(sourceWidth);
-    const objHeight = view.fastScreenToWorldNumber(sourceHeight);
     const scale = typeof object.scale !== 'undefined' ? object.scale : 1;
-    point.x -= (objWidth * scale) / 2;
-    point.y -= (objHeight * scale) / 2;
     view.fastWorldToScreenPoint(point, point);
+    // Offset position and floor to align on pixel boundaries
+    point.subtract((sourceWidth * scale) / 2, (sourceHeight * scale) / 2).floor();
 
     if (object.icon && object.meta) {
       let cx = object.meta.x;

--- a/src/app/scene/scene-view.ts
+++ b/src/app/scene/scene-view.ts
@@ -139,8 +139,8 @@ export class SceneView extends SceneObject implements ISceneView {
     worldCameraPos.x = parseFloat(worldCameraPos.x.toFixed(2));
     worldCameraPos.y = parseFloat(worldCameraPos.y.toFixed(2));
     this.context.translate(
-      worldTilePos.x - worldCameraPos.x,
-      worldTilePos.y - worldCameraPos.y
+      Math.floor(worldTilePos.x - worldCameraPos.x),
+      Math.floor(worldTilePos.y - worldCameraPos.y)
     );
   }
 


### PR DESCRIPTION
 - as the player sprite interpolates between world coordinates, the render position was floating point and it lead to weird sampling in some browsers and bleed from other frames in the animation spritesheet.
 - floor the screen render positiong after translating/scaling to ensure renders always happen on pixel boundaries
 - floor the initial scene view translate as well when setting render state